### PR TITLE
check_esxi_hardware.py: unknown instead of crit

### DIFF
--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -223,6 +223,7 @@ import pywbem
 import re
 import string
 from optparse import OptionParser,OptionGroup
+import os
 
 version = '20150119'
 
@@ -566,7 +567,7 @@ if os_platform != "win32":
   import signal
   def handler(signum, frame):
     print 'UNKNOWN: Execution time too long!'
-    sys.exit(ExitUnknown)
+    os._exit(ExitUnknown)
 
 # connection to host
 verboseoutput("Connection to "+hosturl)

--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -223,7 +223,6 @@ import pywbem
 import re
 import string
 from optparse import OptionParser,OptionGroup
-import os
 
 version = '20150119'
 
@@ -567,7 +566,7 @@ if os_platform != "win32":
   import signal
   def handler(signum, frame):
     print 'UNKNOWN: Execution time too long!'
-    os._exit(ExitUnknown)
+    sys.exit(ExitUnknown)
 
 # connection to host
 verboseoutput("Connection to "+hosturl)

--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -565,8 +565,8 @@ if os_platform != "win32":
   on_windows = False
   import signal
   def handler(signum, frame):
-    print 'CRITICAL: Execution time too long!'
-    sys.exit(ExitCritical)
+    print 'UNKNOWN: Execution time too long!'
+    sys.exit(ExitUnknown)
 
 # connection to host
 verboseoutput("Connection to "+hosturl)
@@ -619,13 +619,13 @@ for classe in ClassesToCheck :
     instance_list = wbemclient.EnumerateInstances(classe)
   except pywbem.cim_operations.CIMError,args:
     if ( args[1].find('Socket error') >= 0 ):
-      print "CRITICAL: %s" %args
-      sys.exit (ExitCritical)
+      print "UNKNOWN: %s" %args
+      sys.exit (ExitUnknown)
     else:
       verboseoutput("Unknown CIM Error: %s" % args)
   except pywbem.cim_http.AuthError,arg:
     verboseoutput("Global exit set to UNKNOWN")
-    GlobalStatus = ExitCritical
+    GlobalStatus = ExitUnknown
     print "UNKNOWN: Authentication Error"
     sys.exit (GlobalStatus)
   else:


### PR DESCRIPTION
Set status to unknown instead of critical for timeouts, authentication errors and such things as those issues are critical for the check itself but not for the service.