### PR TITLE
Distinguish between pywbem 0.7 and 0.8

### DIFF
--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -24,7 +24,7 @@
 # Copyright (c) 2008 David Ligeret
 # Copyright (c) 2009 Joshua Daniel Franklin
 # Copyright (c) 2010 Branden Schneider
-# Copyright (c) 2010-2015 Claudio Kuenzler
+# Copyright (c) 2010-2016 Claudio Kuenzler
 # Copyright (c) 2010 Samir Ibradzic
 # Copyright (c) 2010 Aaron Rogers
 # Copyright (c) 2011 Ludovic Hutin
@@ -231,6 +231,10 @@
 #@ Reason : Removed unused sensor_value variable and string import.
 #@ Reason : Added global hosturl variable declaration after imports.
 #@---------------------------------------------------
+#@ Date   : 20160411
+#@ Author : Claudio Kuenzler (www.claudiokuenzler.com)
+#@ Reason : Distinguish between pywbem 0.7 and 0.8 (which is now released)
+#@---------------------------------------------------
 
 import sys
 import time
@@ -239,7 +243,7 @@ import re
 import pkg_resources
 from optparse import OptionParser,OptionGroup
 
-version = '20151111'
+version = '20160411'
 
 NS = 'root/cimv2'
 hosturl = ''
@@ -589,7 +593,7 @@ verboseoutput("Connection to "+hosturl)
 # pywbem 0.7.0 handling is special, some patched 0.7.0 installations work differently
 pywbemversion = pkg_resources.get_distribution("pywbem").version
 verboseoutput("Found pywbem version "+pywbemversion)
-if '0.7.0' in pywbemversion:
+if '0.7.' in pywbemversion:
   try:
     conntest = pywbem.WBEMConnection(hosturl, (user,password))
     c = conntest.EnumerateInstances('CIM_Card')
@@ -601,7 +605,7 @@ if '0.7.0' in pywbemversion:
     verboseoutput("Connection worked")
     wbemclient = pywbem.WBEMConnection(hosturl, (user,password))
 # pywbem 0.8.0 and later
-elif '0.8.0' in pywbemversion:
+elif '0.8.' in pywbemversion:
   wbemclient = pywbem.WBEMConnection(hosturl, (user,password), NS, no_verification=True)
 
 # Add a timeout for the script. When using with Nagios, the Nagios timeout cannot be < than plugin timeout.


### PR DESCRIPTION
Adapt the code to allow minor versions of 0.7 and 0.8. 
For example: CentOS has a package pywbem 0.7.1, although this doesnt officially exist. And meanwhile 0.8.2 is officially out.