### PR TITLE
Improve pywbem exception handling

### DIFF
--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -298,7 +298,7 @@
 #           Remove python2 compatibility
 #           Remove pywbem 0.7.0 compatibility
 #@---------------------------------------------------
-#@ Date   : 20250214
+#@ Date   : 20250221
 #@ Author : Claudio Kuenzler
 #@ Reason : Update to newer pywbem exception call, catch HTTPError
 #@ Attn   : Requires 'packaging' Python module from now on!
@@ -312,7 +312,7 @@ import json
 from optparse import OptionParser,OptionGroup
 from packaging.version import Version
 
-version = '20250214'
+version = '20250221'
 
 NS = 'root/cimv2'
 hosturl = ''

--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -300,7 +300,7 @@
 #@---------------------------------------------------
 #@ Date   : 20250214
 #@ Author : Claudio Kuenzler
-#@ Reason : Update to newer pywbem exception call, handle HTTPError
+#@ Reason : Update to newer pywbem exception call, catch HTTPError
 #@---------------------------------------------------
 
 import sys
@@ -742,7 +742,7 @@ verboseoutput("Found pywbem version "+pywbemversion)
 verboseoutput("Connection to "+hosturl)
 wbemclient = pywbem.WBEMConnection(hosturl, (user,password), NS, no_verification=True)
 
-# Backward compatibility for pywbem <= 1.0.0
+# Backward compatibility for older pywbem exceptions, big thanks to Claire M.!
 if Version(pywbemversion) >= Version("1.0.0"):
   verboseoutput("pywbem is 1.0.0 or newer")
   import pywbem._cim_operations as PywbemCimOperations

--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -747,10 +747,12 @@ if Version(pywbemversion) >= Version("1.0.0"):
   verboseoutput("pywbem is 1.0.0 or newer")
   import pywbem._cim_operations as PywbemCimOperations
   import pywbem._cim_http as PywbemCimHttp
+  import pywbem._exceptions as PywbemExceptions
 else:
   verboseoutput("pywbem is older than 1.0.0")
   import pywbem.cim_operations as PywbemCimOperations
   import pywbem.cim_http as PywbemCimHttp
+  import pywbem._exceptions as PywbemExceptions
 
 # Add a timeout for the script. When using with Nagios, the Nagios timeout cannot be < than plugin timeout.
 if on_windows == False and timeout > 0:
@@ -778,7 +780,7 @@ if vendor=='auto':
       sys.exit (ExitUnknown)
     else:
       verboseoutput("Unknown CIM Error: %s" % args)
-  except pywbem._exceptions.ConnectionError as args:
+  except PywbemExceptions.ConnectionError as args:
     GlobalStatus = ExitUnknown
     print("UNKNOWN: {}".format(args))
     sys.exit (GlobalStatus)
@@ -813,7 +815,7 @@ for classe in ClassesToCheck :
       sys.exit (ExitUnknown)
     else:
       verboseoutput("Unknown CIM Error: %s" % args)
-  except pywbem._exceptions.ConnectionError as args:
+  except PywbemExceptions.ConnectionError as args:
     GlobalStatus = ExitUnknown
     print("UNKNOWN: {}".format(args))
     sys.exit (GlobalStatus)

--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -22,12 +22,12 @@
 # Copyright (c) 2008 David Ligeret
 # Copyright (c) 2009 Joshua Daniel Franklin
 # Copyright (c) 2010 Branden Schneider
-# Copyright (c) 2010-2024 Claudio Kuenzler
+# Copyright (c) 2010-2025 Claudio Kuenzler
 # Copyright (c) 2010 Samir Ibradzic
 # Copyright (c) 2010 Aaron Rogers
 # Copyright (c) 2011 Ludovic Hutin
 # Copyright (c) 2011 Carsten Schoene
-# Copyright (c) 2011-2012 Phil Randal
+# Copyright (c) 2011-2012,2025 Phil Randal
 # Copyright (c) 2011 Fredrik Aslund
 # Copyright (c) 2011 Bertrand Jomin
 # Copyright (c) 2011 Ian Chard
@@ -298,6 +298,10 @@
 #           Remove python2 compatibility
 #           Remove pywbem 0.7.0 compatibility
 #@---------------------------------------------------
+#@ Date   : 20250214
+#@ Author : Phil Randal and Claudio Kuenzler
+#@ Reason : Update to newer pywbem exception call
+#@---------------------------------------------------
 
 import sys
 import time
@@ -306,7 +310,7 @@ import re
 import json
 from optparse import OptionParser,OptionGroup
 
-version = '20241129'
+version = '20250214'
 
 NS = 'root/cimv2'
 hosturl = ''
@@ -754,7 +758,7 @@ ExitMsg = ""
 if vendor=='auto':
   try:
     c=wbemclient.EnumerateInstances('CIM_Chassis')
-  except pywbem.cim_operations.CIMError as args:
+  except pywbem._cim_operations.CIMError as args:
     if ( args[1].find('Socket error') >= 0 ):
       print("UNKNOWN: {}".format(args))
       sys.exit (ExitUnknown)
@@ -767,7 +771,7 @@ if vendor=='auto':
     GlobalStatus = ExitUnknown
     print("UNKNOWN: {}".format(args))
     sys.exit (GlobalStatus)
-  except pywbem.cim_http.AuthError as arg:
+  except pywbem._cim_http.AuthError as arg:
     verboseoutput("Global exit set to UNKNOWN")
     GlobalStatus = ExitUnknown
     print("UNKNOWN: Authentication Error")

--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -27,7 +27,7 @@
 # Copyright (c) 2010 Aaron Rogers
 # Copyright (c) 2011 Ludovic Hutin
 # Copyright (c) 2011 Carsten Schoene
-# Copyright (c) 2011-2012,2025 Phil Randal
+# Copyright (c) 2011-2012 Phil Randal
 # Copyright (c) 2011 Fredrik Aslund
 # Copyright (c) 2011 Bertrand Jomin
 # Copyright (c) 2011 Ian Chard
@@ -301,6 +301,7 @@
 #@ Date   : 20250214
 #@ Author : Claudio Kuenzler
 #@ Reason : Update to newer pywbem exception call, catch HTTPError
+#@ Attn   : Requires 'packaging' Python module from now on!
 #@---------------------------------------------------
 
 import sys

--- a/check_esxi_hardware.py
+++ b/check_esxi_hardware.py
@@ -299,8 +299,8 @@
 #           Remove pywbem 0.7.0 compatibility
 #@---------------------------------------------------
 #@ Date   : 20250214
-#@ Author : Phil Randal and Claudio Kuenzler
-#@ Reason : Update to newer pywbem exception call
+#@ Author : Claudio Kuenzler
+#@ Reason : Update to newer pywbem exception call, handle HTTPError
 #@---------------------------------------------------
 
 import sys
@@ -752,7 +752,7 @@ else:
   verboseoutput("pywbem is older than 1.0.0")
   import pywbem.cim_operations as PywbemCimOperations
   import pywbem.cim_http as PywbemCimHttp
-  import pywbem._exceptions as PywbemExceptions
+  import pywbem.exceptions as PywbemExceptions
 
 # Add a timeout for the script. When using with Nagios, the Nagios timeout cannot be < than plugin timeout.
 if on_windows == False and timeout > 0:
@@ -781,6 +781,10 @@ if vendor=='auto':
     else:
       verboseoutput("Unknown CIM Error: %s" % args)
   except PywbemExceptions.ConnectionError as args:
+    GlobalStatus = ExitUnknown
+    print("UNKNOWN: {}".format(args))
+    sys.exit (GlobalStatus)
+  except PywbemExceptions.HTTPError as args:
     GlobalStatus = ExitUnknown
     print("UNKNOWN: {}".format(args))
     sys.exit (GlobalStatus)
@@ -816,6 +820,10 @@ for classe in ClassesToCheck :
     else:
       verboseoutput("Unknown CIM Error: %s" % args)
   except PywbemExceptions.ConnectionError as args:
+    GlobalStatus = ExitUnknown
+    print("UNKNOWN: {}".format(args))
+    sys.exit (GlobalStatus)
+  except PywbemExceptions.HTTPError as args:
     GlobalStatus = ExitUnknown
     print("UNKNOWN: {}".format(args))
     sys.exit (GlobalStatus)


### PR DESCRIPTION
Improve pywbem exception handling across old (< 1.0.0) and newer (>= 1.0.0) pywbem versions. 

Also handle HTTPError exception. This is useful when the plugin is mistakenly pointed to a HTTP endpoint which does not serve any CIM elements (ESXi HTTPS UI for example).

**Attention: The plugin requires the Python module "packaging" from now on!**

This PR fixes #54 .

Thanks to @philrandal and @clairem-sl for hints!